### PR TITLE
feat(zRPCClient): add option to initiate a server request upon timeout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,10 @@ target_compile_options(${PROJECT_NAME} PUBLIC ${compile_options})
 # Test applications
 ###############################################################################
 if (ZRPC_BUILD_TESTS)
+  add_executable(clientDetached tests/clientDetached.cpp)
+  target_link_libraries(clientDetached zRPC)
+  target_compile_options(clientDetached PUBLIC ${compile_options})
+
   add_executable(client tests/client.cpp)
   target_link_libraries(client zRPC)
   target_compile_options(client PUBLIC ${compile_options})

--- a/include/zRPC.hpp
+++ b/include/zRPC.hpp
@@ -45,7 +45,6 @@
 
 namespace zRPC
 {
-
 /**
  * @class Server zRPC.hpp "zRPC.hpp"
  *
@@ -233,20 +232,34 @@ public:
    * @param[in] identity Identity string to use for the client.
    * @param[in] uri Zero-MQ address:port to bind listening socket to.
    */
-  explicit Client(const std::string &identity,
-                  const std::string &uri);
+  explicit Client(const std::string &identity, const std::string &uri);
 
   /**
    * @brief Call the RPC with the given name and given arguments
    *
    * @tparam A Variadic argument list
-   * @param[in] name Name of the RPC to call on the remote serveer
+   * @param[in] name Name of the RPC to call on the remote server
    * @param[in] args Variadic argument list to pass to the remote server
    * @return msgpack::object_handle MessagePack'd object handle containing
    * server response (if any)
    */
   template <typename... A>
   msgpack::object_handle call(const std::string &name, A... args);
+
+  /**
+   * @brief Call the RPC with the given name and given arguments
+   *
+   * @tparam A Variadic argument list
+   * @param[in] timeout Timeout in ms before dropping the request
+   * @param[in] name Name of the RPC to call on the remote server
+   * @param[in] args Variadic argument list to pass to the remote server
+   * @return msgpack::object_handle MessagePack'd object handle containing
+   * server response (if any)
+   */
+  template <typename... A>
+  msgpack::object_handle call(const int timeout,
+                              const std::string &name,
+                              A... args);
 };
 
 /**

--- a/tests/clientDetached.cpp
+++ b/tests/clientDetached.cpp
@@ -1,0 +1,74 @@
+/*
+ * @file   clientDetached.cpp
+ * @author Seif Hadrich
+ * @date   3-May-2021 10:30:00 am
+ *
+ * @brief demo application for running a client in detached non blocking thread
+ *
+ * @copyright Jonathan Haws -- 2021
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <thread>
+#include "zRPC.hpp"
+
+class Message
+{
+public:
+  int v{-1};
+
+  MSGPACK_DEFINE(v)
+};
+
+void f4(zRPC::Client &client, int timeout)
+{
+  try
+  {
+    Message m;
+    m.v = 1;
+    auto res = client.call(timeout, "f4", m);
+    std::cout << "f4 result = " << res.get().as<Message>().v << std::endl;
+  }
+  catch (const std::exception &e)
+  {
+    std::cerr << e.what() << '\n';
+  }
+}
+
+int main(void)
+{
+  zRPC::Client client("TEST-CLIENT-Detached", "tcp://localhost:12345");
+
+  int i = 0;
+  while (i < 100)
+  {
+    // Run f4 client with timeout enabled
+    int timeout = 100;  // 100ms
+    std::cout << "Call detached f4 thread number " << i << std::endl;
+    std::thread(f4, std::ref(client), timeout).detach();
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+    i++;
+  }
+
+  client.call("terminate");  // shutdown the server
+  sleep(1);
+}


### PR DESCRIPTION
Implement an RPC call with a timeout mechanism and self-cleaning functionality to automatically handle resource cleanup if the call exceeds the specified duration.